### PR TITLE
feat: validate nonce time

### DIFF
--- a/src/type.ts
+++ b/src/type.ts
@@ -4,7 +4,12 @@ export type BaseSteamOpenIdStrategyOptions = {
   returnURL: string;
   /**
    * Maximum time delay between the nonce creation and the nonce verification,
-   * in miliseconds.
+   * in seconds.
+   *
+   * nonce includes a timestamp we can validate against the current time,
+   * while the steam server validates this as well, you might want to
+   * set maximum number of seconds between the nonce creation and the nonce
+   * verification.
    */
   maxNonceTimeDelay?: number;
 };

--- a/src/type.ts
+++ b/src/type.ts
@@ -2,6 +2,11 @@ import { DoneCallback } from 'passport';
 
 export type BaseSteamOpenIdStrategyOptions = {
   returnURL: string;
+  /**
+   * Maximum time delay between the nonce creation and the nonce verification,
+   * in miliseconds.
+   */
+  maxNonceTimeDelay?: number;
 };
 
 export type SteamOpenIdStrategyOptionsWithProfile = {
@@ -39,6 +44,10 @@ export enum SteamOpenIdErrorType {
    * SteamId is not valid.
    */
   InvalidSteamId = 3,
+  /**
+   * Nonce has expired.
+   */
+  NonceExpired = 4,
 }
 
 /** When profile is not used, we just send a steamid. */

--- a/test/setup/data.ts
+++ b/test/setup/data.ts
@@ -1,12 +1,16 @@
-import { VALID_NONCE, VALID_OPENID_ENDPOINT } from '../../src';
+import {
+  SteamOpenIdQuery,
+  VALID_NONCE,
+  VALID_OPENID_ENDPOINT,
+} from '../../src';
 
 export const RETURN_URL = '/auth/steam';
 
 export const query: {
-  properties: Record<string, string>;
-  get(): Record<string, string>;
-  change(change: Record<string, string>): Record<string, string>;
-  remove(property: string): Record<string, string>;
+  properties: SteamOpenIdQuery;
+  get(): SteamOpenIdQuery;
+  change(change: Partial<SteamOpenIdQuery>): SteamOpenIdQuery;
+  remove(property: keyof SteamOpenIdQuery): SteamOpenIdQuery;
 } = {
   /**
    * Valid query properties
@@ -25,15 +29,15 @@ export const query: {
     'openid.sig': 'dc6e2a79de2c6aceac495ad5f4c6b6e0bfe30',
   },
 
-  get() {
+  get(): SteamOpenIdQuery {
     return { ...this.properties };
   },
 
-  change(change: Record<string, string>) {
+  change(change: Partial<SteamOpenIdQuery>): SteamOpenIdQuery {
     return { ...this.get(), ...change };
   },
 
-  remove(property: string) {
+  remove(property: keyof SteamOpenIdQuery): SteamOpenIdQuery {
     const properties = this.get();
     delete properties[property];
     return properties;

--- a/test/setup/data.ts
+++ b/test/setup/data.ts
@@ -6,6 +6,8 @@ import {
 
 export const RETURN_URL = '/auth/steam';
 
+export const getISODate = (date: Date) => date.toISOString().split('.')[0] + 'Z';
+
 export const query: {
   properties: SteamOpenIdQuery;
   get(): SteamOpenIdQuery;
@@ -22,7 +24,7 @@ export const query: {
     'openid.claimed_id': `https://steamcommunity.com/openid/id/76561197960435530`,
     'openid.return_to': RETURN_URL,
     'openid.op_endpoint': VALID_OPENID_ENDPOINT,
-    'openid.response_nonce': `${new Date().toJSON()}8df86bac92ad1addaf3735a5aabdc6e2a7`,
+    'openid.response_nonce': `${getISODate(new Date())}8df86bac92ad1addaf3735a5aabdc6e2a7`,
     'openid.assoc_handle': '1234567890',
     'openid.signed':
       'signed,op_endpoint,claimed_id,identity,return_to,response_nonce,assoc_handle',

--- a/test/strategy.ts
+++ b/test/strategy.ts
@@ -15,7 +15,7 @@ import {
   VALID_OPENID_ENDPOINT,
   PLAYER_SUMMARY_URL,
 } from '../src';
-import { RETURN_URL, query } from './setup/data';
+import { RETURN_URL, getISODate, query } from './setup/data';
 
 chai.use(chaiAsPromised);
 
@@ -765,27 +765,28 @@ describe('SteamOpenIdStrategy Unit Test', () => {
     });
 
     it('Setting set, nonce expired', () => {
-      strategy['maxNonceTimeDelay'] = HOUR;
+      strategy['maxNonceTimeDelay'] = HOUR / 1000;
 
       expect(
         strategy['hasNonceExpired'](
           query.change({
-            'openid.response_nonce': `${new Date(
-              Date.now() - 2 * HOUR,
-            ).toJSON()}8df86bac92ad1addaf3735a5aabdc6e2a7`,
+            'openid.response_nonce': `${getISODate(
+              new Date(Date.now() - 2 * HOUR),
+            )}8df86bac92ad1addaf3735a5aabdc6e2a7`,
           }),
         ),
       ).equal(true);
     });
 
     it('Setting set, nonce not expired', () => {
-      strategy['maxNonceTimeDelay'] = 1000 * 60 * 60;
+      strategy['maxNonceTimeDelay'] = HOUR / 1000;
+
       expect(
         strategy['hasNonceExpired'](
           query.change({
-            'openid.response_nonce': `${new Date(
-              Date.now() - HOUR / 2,
-            ).toJSON()}8df86bac92ad1addaf3735a5aabdc6e2a7`,
+            'openid.response_nonce': `${getISODate(
+              new Date(Date.now() + HOUR / 2),
+            )}8df86bac92ad1addaf3735a5aabdc6e2a7`,
           }),
         ),
       ).equal(false);

--- a/test/strategy.ts
+++ b/test/strategy.ts
@@ -214,12 +214,14 @@ describe('SteamOpenIdStrategy Unit Test', () => {
     let getQueryStub: sinon.SinonStub;
     let hasAuthQueryStub: sinon.SinonStub;
     let isQueryValidStub: sinon.SinonStub;
+    let hasNonceExpiredStub: sinon.SinonStub;
     let validateAgainstSteamStub: sinon.SinonStub;
 
     beforeEach(() => {
       getQueryStub = sinon.stub(strategy as any, 'getQuery').returns(query);
       hasAuthQueryStub = sinon.stub(strategy as any, 'hasAuthQuery');
       isQueryValidStub = sinon.stub(strategy as any, 'isQueryValid');
+      hasNonceExpiredStub = sinon.stub(strategy as any, 'hasNonceExpired');
       validateAgainstSteamStub = sinon.stub(
         strategy as any,
         'validateAgainstSteam',
@@ -237,6 +239,7 @@ describe('SteamOpenIdStrategy Unit Test', () => {
       hasAuthQueryStub.returns(true);
       isQueryValidStub.returns(true);
       validateAgainstSteamStub.resolves(true);
+      hasNonceExpiredStub.returns(false);
 
       const steamid = '76561197960435530';
       const user = { steamid: '76561197960435530' };
@@ -253,6 +256,8 @@ describe('SteamOpenIdStrategy Unit Test', () => {
       expect(getUserStub.calledWithExactly(steamid)).equal(true);
       expect(isQueryValidStub.callCount).equal(1);
       expect(isQueryValidStub.calledWithExactly(query)).equal(true);
+      expect(hasNonceExpiredStub.callCount).equal(1);
+      expect(hasNonceExpiredStub.calledWithExactly(query)).equal(true);
       expect(validateAgainstSteamStub.callCount).equal(1);
       expect(validateAgainstSteamStub.calledWithExactly(query)).equal(true);
     });
@@ -269,6 +274,9 @@ describe('SteamOpenIdStrategy Unit Test', () => {
 
       expect(err).to.be.instanceOf(SteamOpenIdError);
       expect(err).to.have.property('code', SteamOpenIdErrorType.InvalidMode);
+      expect(isQueryValidStub.callCount).equal(0);
+      expect(hasNonceExpiredStub.callCount).equal(0);
+      expect(validateAgainstSteamStub.callCount).equal(0);
     });
 
     it('Query is invalid', async () => {
@@ -286,11 +294,35 @@ describe('SteamOpenIdStrategy Unit Test', () => {
       expect(err).to.have.property('code', SteamOpenIdErrorType.InvalidQuery);
       expect(isQueryValidStub.callCount).equal(1);
       expect(isQueryValidStub.calledWithExactly(query)).equal(true);
+      expect(hasNonceExpiredStub.callCount).equal(0);
+      expect(validateAgainstSteamStub.callCount).equal(0);
+    });
+
+    it('Nonce has expired', async () => {
+      hasAuthQueryStub.returns(true);
+      isQueryValidStub.returns(true);
+      hasNonceExpiredStub.returns(true);
+
+      let err: any;
+      try {
+        await strategy.handleRequest(request);
+      } catch (e) {
+        err = e;
+      }
+
+      expect(err).to.be.instanceOf(SteamOpenIdError);
+      expect(err).to.have.property('code', SteamOpenIdErrorType.NonceExpired);
+      expect(isQueryValidStub.callCount).equal(1);
+      expect(isQueryValidStub.calledWithExactly(query)).equal(true);
+      expect(hasNonceExpiredStub.callCount).equal(1);
+      expect(hasNonceExpiredStub.calledWithExactly(query)).equal(true);
+      expect(validateAgainstSteamStub.callCount).equal(0);
     });
 
     it('Steam rejects this authentication request', async () => {
       hasAuthQueryStub.returns(true);
       isQueryValidStub.returns(true);
+      hasNonceExpiredStub.returns(false);
       validateAgainstSteamStub.resolves(false);
 
       let err: any;
@@ -304,6 +336,8 @@ describe('SteamOpenIdStrategy Unit Test', () => {
       expect(err).to.have.property('code', SteamOpenIdErrorType.Unauthorized);
       expect(isQueryValidStub.callCount).equal(1);
       expect(isQueryValidStub.calledWithExactly(query)).equal(true);
+      expect(hasNonceExpiredStub.callCount).equal(1);
+      expect(hasNonceExpiredStub.calledWithExactly(query)).equal(true);
       expect(validateAgainstSteamStub.callCount).equal(1);
       expect(validateAgainstSteamStub.calledWithExactly(query)).equal(true);
     });
@@ -720,6 +754,41 @@ describe('SteamOpenIdStrategy Unit Test', () => {
 
       expect(err).instanceOf(SteamOpenIdError);
       expect(err).to.have.property('code', SteamOpenIdErrorType.InvalidSteamId);
+    });
+  });
+
+  describe('hasNonceExpired', () => {
+    const HOUR = 1000 * 60 * 60;
+
+    it('No setting set, could not expire', () => {
+      expect(strategy['hasNonceExpired'](query.properties)).equal(false);
+    });
+
+    it('Setting set, nonce expired', () => {
+      strategy['maxNonceTimeDelay'] = HOUR;
+
+      expect(
+        strategy['hasNonceExpired'](
+          query.change({
+            'openid.response_nonce': `${new Date(
+              Date.now() - 2 * HOUR,
+            ).toJSON()}8df86bac92ad1addaf3735a5aabdc6e2a7`,
+          }),
+        ),
+      ).equal(true);
+    });
+
+    it('Setting set, nonce not expired', () => {
+      strategy['maxNonceTimeDelay'] = 1000 * 60 * 60;
+      expect(
+        strategy['hasNonceExpired'](
+          query.change({
+            'openid.response_nonce': `${new Date(
+              Date.now() - HOUR / 2,
+            ).toJSON()}8df86bac92ad1addaf3735a5aabdc6e2a7`,
+          }),
+        ),
+      ).equal(false);
     });
   });
 });


### PR DESCRIPTION
Add optional nonce validation setting, that adds an extra security measure. We take ISO 8601 date from the `openid.response_nonce` parameter and check if there was a large delay between the creation and verification, user can set `maxNonceTimeDelay` in seconds for this option to work.

Thought it's not necessary or recommended, it might suit some use-cases. Steam authentication server validates this date as well.