### PR TITLE
Fix a 403 error when attempting to validate the query against the openid endpoint

### DIFF
--- a/src/strategy.ts
+++ b/src/strategy.ts
@@ -322,6 +322,8 @@ export class SteamOpenIdStrategy<
         maxRedirects: 0,
         headers: {
           'Content-Type': 'application/x-www-form-urlencoded',
+          'Origin': 'https://steamcommunity.com',
+          'Referer': 'https://steamcommunity.com',
         },
       })
       .then(({ data, status }) => {


### PR DESCRIPTION
Yeah idk why steam did this but suddenly https://steamcommunity.com/openid/login started returning a 403 error when validating the query.
Adding Origin and Referer headers of 'https://steamcommunity.com/' fixes it