### PR TITLE
refactor: make axios optional

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,6 +21,6 @@ module.exports = {
     '@typescript-eslint/explicit-function-return-type': 'off',
     '@typescript-eslint/explicit-module-boundary-types': 'off',
     '@typescript-eslint/no-explicit-any': 'off',
-    'sonarjs/no-duplicate-string': 'off'
+    'sonarjs/no-duplicate-string': 'off',
   },
 };

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # passport-steam-openid
 Passport strategy for authenticating with steam openid without the use of 3rd party openid packages,
 which have been proved to be source of many exploits of steam openid system, apparently by design.
-This package only relies on [passport](https://www.passportjs.org/) and [axios](https://axios-http.com/).
+This package only relies on [passport](https://www.passportjs.org/), optionally on [axios](https://axios-http.com/),
+as it is the default http client, you can add your own implementation for extra security.
 
 Library is fully covered with tests, both unit and integration tests to make sure everything runs correctly.
 
@@ -17,6 +18,7 @@ Options object has the following properties:
 - `profile` - If set to true, it will fetch user profile from steam api, otherwise only steamid will be returned
 - `apiKey` - Steam api key, required if `options.profile` is set to true
 - `maxNonceTimeDelay` - Optional, in seconds, time between creation and verification of nonce date, if not set no verification occurs.
+- `httpClient` - Optional, you can implement `IAxiosLikeHttpClient` interface for your own http client
 
 Second parameter of `SteamOpenIdStrategy` is a callback function used for verifying logged in user, with the following parameters:
 - `req` - Express request object

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.1.6",
       "license": "MIT",
       "dependencies": {
-        "axios": "^1.4.0",
+        "axios": "*",
         "passport": "^0.6.0"
       },
       "devDependencies": {
@@ -45,6 +45,9 @@
         "sinon": "^15.2.0",
         "ts-node": "^10.9.1",
         "typescript": "^5.1.3"
+      },
+      "optionalDependencies": {
+        "axios": "^1.10.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -2425,7 +2428,8 @@
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "devOptional": true
     },
     "node_modules/at-least-node": {
       "version": "1.0.0",
@@ -2441,6 +2445,7 @@
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.10.0.tgz",
       "integrity": "sha512-/1xYAC4MP/HEG+3duIhFr4ZQXR4sQXOIe+o6sdqzeykGLx6Upp/1p8MHqhINOvGeP7xyNHe7tsiJByc4SSVUxw==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
@@ -3133,6 +3138,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "devOptional": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -3637,6 +3643,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "devOptional": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -4695,6 +4702,7 @@
           "url": "https://github.com/sponsors/RubenVerborgh"
         }
       ],
+      "optional": true,
       "engines": {
         "node": ">=4.0"
       },
@@ -4721,6 +4729,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
       "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "devOptional": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -6713,6 +6722,7 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "devOptional": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -6721,6 +6731,7 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "devOptional": true,
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -10612,7 +10623,8 @@
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "optional": true
     },
     "node_modules/punycode": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
   "author": "glencoco",
   "license": "MIT",
   "dependencies": {
-    "axios": "^1.4.0",
     "passport": "^0.6.0"
   },
   "devDependencies": {
@@ -68,5 +67,8 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/danocmx/passport-steam-openid.git"
+  },
+  "optionalDependencies": {
+    "axios": "^1.10.0"
   }
 }

--- a/src/type.ts
+++ b/src/type.ts
@@ -1,5 +1,25 @@
 import { DoneCallback } from 'passport';
 
+export type HttpOpts = {
+  maxRedirects?: number;
+  params?: Record<string, any>;
+  headers?: Record<string, any>;
+};
+
+export type HttpRes<TResponse> = {
+  data: TResponse;
+  status?: number;
+};
+
+export interface IAxiosLikeHttpClient {
+  get<TResponse>(url: string, opts?: HttpOpts): Promise<HttpRes<TResponse>>;
+  post<TResponse>(
+    url: string,
+    data?: any,
+    opts?: HttpOpts,
+  ): Promise<HttpRes<TResponse>>;
+}
+
 export type BaseSteamOpenIdStrategyOptions = {
   returnURL: string;
   /**
@@ -12,6 +32,7 @@ export type BaseSteamOpenIdStrategyOptions = {
    * verification.
    */
   maxNonceTimeDelay?: number;
+  httpClient?: IAxiosLikeHttpClient;
 };
 
 export type SteamOpenIdStrategyOptionsWithProfile = {

--- a/test/strategy.ts
+++ b/test/strategy.ts
@@ -533,7 +533,7 @@ describe('SteamOpenIdStrategy Unit Test', () => {
     const body = 'body';
 
     beforeEach(() => {
-      axiosPostStub = sinon.stub(strategy['axios'], 'post');
+      axiosPostStub = sinon.stub(strategy['http'], 'post');
       getOpenIdValidationRequestBodyStub = sinon
         .stub(strategy as any, 'getOpenIdValidationRequestBody')
         .returns(body);
@@ -689,7 +689,7 @@ describe('SteamOpenIdStrategy Unit Test', () => {
         returnURL: RETURN_URL,
       });
 
-      axiosGetStub = sinon.stub(strategy['axios'], 'get');
+      axiosGetStub = sinon.stub(strategy['http'], 'get');
     });
 
     afterEach(() => {


### PR DESCRIPTION
Removes axios as hard dependency, and now makes it optional. You can implement your own http client using `IAxiosLikeHttpClient` interface and supply it in `httpClient` option.

To remain backwards compatible, library will attempt to import axios as a default http client if none is supplied.