### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,5 +1,8 @@
 name: Pull Request
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches: [ master ]


### PR DESCRIPTION
Potential fix for [https://github.com/danocmx/passport-steam-openid/security/code-scanning/5](https://github.com/danocmx/passport-steam-openid/security/code-scanning/5)

In general, the fix is to add an explicit `permissions:` block that restricts the `GITHUB_TOKEN` to the minimal scopes the workflow needs. For a workflow that only checks out code and runs Node.js builds/tests, `contents: read` is usually sufficient, since no writes to the repository or other resources are performed.

The best way to fix this without changing existing functionality is to add a `permissions:` section at the workflow root (top-level, alongside `name` and `on`). This will apply to all jobs in the file, including `test_pull_request`, and will constrain the token appropriately. Based on the current steps (checkout, setup-node, npm install/build/test), only repository read access is required, so we can set:

```yaml
permissions:
  contents: read
```

This should be inserted between the `name:` and `on:` keys (lines 1–3) in `.github/workflows/pull-request.yml`. No imports, methods, or other definitions are needed; this is purely a YAML configuration change within the workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
